### PR TITLE
Fix syntax error: Add missing closing brace for main IIFE

### DIFF
--- a/js/balance/balance-app.js
+++ b/js/balance/balance-app.js
@@ -1940,5 +1940,7 @@ handleBedarfAnpassungClick(e) {
     window.runPropertyChecks = runPropertyChecks;
     
     document.addEventListener('DOMContentLoaded', initDevHarness);
-})();
+})(); // Ende Developer Test Harness IIFE
+
+})(); // Ende Hauptanwendungs-IIFE
 


### PR DESCRIPTION
Problem: Die Datei hatte einen "Unexpected end of input" Syntaxfehler in Zeile 1945.

Ursache: Die Hauptanwendungs-IIFE (Zeile 2) wurde nie geschlossen. Es gab eine verschachtelte Developer Test Harness IIFE (Zeile 1372-1943), die korrekt geschlossen wurde, aber die äußere IIFE fehlte die abschließende })();

Lösung: Hinzufügen von })(); nach Zeile 1943, um die Hauptanwendungs-IIFE zu schließen.

Dies behebt:
- Feldaktualisierungen funktionieren nicht
- Drucktasten (z.B. Jahresabschluss) werden nicht ausgeführt
- JavaScript-Syntaxfehler verhinderte die Ausführung der gesamten Anwendung