### PR TITLE
Update README.md: Document Simulator app modularization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,33 @@
 
 Ein umfassendes Tool zur Portfolioverwaltung und Ruhestandsplanung mit Monte-Carlo-Simulationen.
 
-## 📦 Projektstruktur (Neu modularisiert!)
+## 📦 Projektstruktur (Vollständig modularisiert!)
 
 ```
 Ruhestand-App-Final/
 ├── css/
-│   └── balance.css              # Balance-App Styles (~530 Zeilen)
+│   ├── balance.css              # Balance-App Styles (~530 Zeilen)
+│   └── simulator.css            # Simulator Styles (99 Zeilen)
 │
 ├── js/
 │   ├── balance/
 │   │   └── balance-app.js       # Balance-App Logik (~1.944 Zeilen)
 │   │
-│   ├── simulator/
-│   │   └── (noch zu modularisieren)
-│   │
 │   └── shared/
 │       └── (für gemeinsame Komponenten)
+│
+├── simulator-main.js            # Simulator Hauptmodul (559 Zeilen)
+├── simulator-engine.js          # Simulations-Engine (411 Zeilen)
+├── simulator-results.js         # Ergebnis-Rendering (297 Zeilen)
+├── simulator-portfolio.js       # Portfolio-Verwaltung (343 Zeilen)
+├── simulator-heatmap.js         # Heatmap-Visualisierung (315 Zeilen)
+├── simulator-utils.js           # Hilfsfunktionen (146 Zeilen)
+├── simulator-data.js            # Daten-Konstanten (84 Zeilen)
 │
 ├── engine.js                    # Gemeinsame Berechnungs-Engine (959 Zeilen)
 ├── Balance.html                 # Balance-App (255 Zeilen - vorher 2.411!)
 ├── Balance.html.backup          # Original-Backup
-├── Simulator.html               # Monte-Carlo Simulator (2.380 Zeilen)
+├── Simulator.html               # Monte-Carlo Simulator (242 Zeilen - vorher 2.380!)
 └── README.md                    # Diese Datei
 ```
 
@@ -46,7 +52,7 @@ Ruhestand-App-Final/
 
 ### 2. Simulator.html - Monte-Carlo-Ruhestandssimulator
 
-**Zweck:** Langfristige Portfolionachhaltigkeitsmodellierung (noch zu modularisieren)
+**Zweck:** Langfristige Portfolionachhaltigkeitsmodellierung mit stochastischen Szenarien
 
 **Hauptfunktionen:**
 - 1000+ Monte-Carlo-Simulationen über 35+ Jahre
@@ -55,6 +61,17 @@ Ruhestand-App-Final/
 - Pflegefall-Szenarien mit Kostenmodellierung
 - Detaillierte Wahrscheinlichkeitsmetriken (P10, P50, P90)
 - Heatmap-Visualisierungen
+
+**Technologie:** HTML5, CSS3, ES6-Module (vollständig modularisiert)
+
+**Module:**
+- **simulator-main.js** - Hauptorchestrierung, Monte-Carlo & Backtest
+- **simulator-engine.js** - Jahres-Simulationslogik, State Management
+- **simulator-results.js** - Ergebnis-Rendering & Visualisierung
+- **simulator-portfolio.js** - Portfolio-Initialisierung & -Verwaltung
+- **simulator-heatmap.js** - Heatmap-Generierung & Canvas-Rendering
+- **simulator-utils.js** - Hilfsfunktionen (RNG, Quantile, Formatierung)
+- **simulator-data.js** - Historische Daten & Konstanten
 
 ### 3. engine.js - Gemeinsame Berechnungs-Engine (v31.0)
 
@@ -75,6 +92,24 @@ Ruhestand-App-Final/
 | ~214 Zeilen CSS inline | css/balance.css | ✅ |
 | ~1.946 Zeilen JS inline | js/balance/balance-app.js | ✅ |
 
+### Simulator.html - Vorher vs. Nachher
+
+| Vorher | Nachher | Reduktion |
+|--------|---------|-----------|
+| **2.380 Zeilen** | **242 Zeilen** | **-90%** |
+| Monolithisches JavaScript | 7 ES6-Module | ✅ |
+| Inline CSS | simulator.css | ✅ |
+| ~2.138 Zeilen JS inline | 2.155 Zeilen verteilt auf Module | ✅ |
+
+**Module-Aufteilung:**
+- simulator-main.js (559) - Orchestrierung
+- simulator-engine.js (411) - Simulationslogik
+- simulator-portfolio.js (343) - Portfolio-Management
+- simulator-heatmap.js (315) - Visualisierung
+- simulator-results.js (297) - Rendering
+- simulator-utils.js (146) - Hilfsfunktionen
+- simulator-data.js (84) - Konstanten
+
 ### Vorteile der neuen Struktur
 
 ✅ **Übersichtlichkeit** - Jede Datei hat eine klare Verantwortung  
@@ -85,23 +120,26 @@ Ruhestand-App-Final/
 
 ## 🎨 Verwendung
 
-### Balance-App öffnen
+### Apps öffnen
 
-Öffne `Balance.html` in einem modernen Browser:
+Öffne die gewünschte App in einem modernen Browser:
 
 ```bash
-# Linux/Mac
+# Balance-App (Portfolio-Management)
 open Balance.html
+
+# Simulator-App (Monte-Carlo-Analysen)
+open Simulator.html
 
 # oder direkt in Browser ziehen
 ```
 
 **Empfohlene Browser:**
-- Chrome/Edge (Chromium-basiert)
+- Chrome/Edge (Chromium-basiert) - empfohlen für ES6-Module
 - Firefox
 - Safari
 
-### Tastaturkürzel
+### Tastaturkürzel (Balance-App)
 
 - **Alt + J** - Jahresabschluss erstellen
 - **Alt + E** - Export
@@ -121,9 +159,10 @@ Die App speichert Daten im **Browser LocalStorage**:
 ## 🔧 Nächste Schritte (Empfohlene Verbesserungen)
 
 ### Kurzfristig (Quick Wins)
-- [ ] Simulator.html modularisieren (analog zu Balance.html)
+- [x] ~~Simulator.html modularisieren~~ (✅ Erledigt!)
 - [ ] Gemeinsame CSS-Variablen in css/shared.css auslagern
 - [ ] Formatierungsfunktionen in js/shared/formatters.js
+- [ ] Balance-App auf ES6-Module umstellen (analog zu Simulator)
 
 ### Mittelfristig
 - [ ] Build-System einführen (Vite/esbuild)
@@ -132,15 +171,16 @@ Die App speichert Daten im **Browser LocalStorage**:
 - [ ] ESLint/Prettier konfigurieren
 
 ### Langfristig
-- [ ] In ES6-Module umwandeln
-- [ ] Web Workers für Simulator-Performance
+- [ ] Web Workers für Simulator-Performance (1000+ Simulationen)
 - [ ] PWA-Features (offline-fähig, installierbar)
-- [ ] Chart-Bibliothek integrieren (Chart.js)
+- [ ] Chart-Bibliothek integrieren (Chart.js/Plotly)
+- [ ] Shared State Management (Zustand/Jotai)
 
 ## 📊 Technische Details
 
 ### Architektur
 
+#### Balance-App (Klassisch)
 ```
 ┌─────────────────────────────────────────┐
 │          Balance.html (UI)              │
@@ -171,6 +211,36 @@ Die App speichert Daten im **Browser LocalStorage**:
 └─────────────────────────────────────────┘
 ```
 
+#### Simulator-App (ES6-Module)
+```
+┌─────────────────────────────────────────┐
+│        Simulator.html (UI)              │
+├─────────────────────────────────────────┤
+│  - HTML-Struktur (242 Zeilen)          │
+│  - Lädt: simulator.css                 │
+│  - Lädt: simulator-main.js (Module)    │
+│  - Lädt: engine.js                     │
+└─────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────┐
+│      simulator-main.js (Entry)          │
+├─────────────────────────────────────────┤
+│  - Monte-Carlo-Orchestrierung          │
+│  - Backtest-Runner                     │
+│  - Progress-Tracking                   │
+└─────────────────────────────────────────┘
+         ↓              ↓            ↓
+    ┌────────┐   ┌──────────┐  ┌─────────┐
+    │ engine │   │portfolio │  │ results │
+    │ (411)  │   │  (343)   │  │  (297)  │
+    └────────┘   └──────────┘  └─────────┘
+         ↓              ↓            ↓
+    ┌────────┐   ┌──────────┐  ┌─────────┐
+    │ utils  │   │ heatmap  │  │  data   │
+    │ (146)  │   │  (315)   │  │  (84)   │
+    └────────┘   └──────────┘  └─────────┘
+```
+
 ### Marktregime (7 Szenarien)
 
 1. **peak_hot** - Allzeithoch mit starkem Momentum
@@ -198,27 +268,35 @@ THRESHOLDS: {
 
 ## 📝 Versionshistorie
 
-### v2.0 (2025-01-XX) - Modularisierung
-- ✅ Balance.html modularisiert (2.411 → 255 Zeilen)
-- ✅ CSS in separate Datei ausgelagert
-- ✅ JavaScript in separate Datei ausgelagert
+### v3.0 (2025-01-XX) - Vollständige Modularisierung
+- ✅ Simulator.html modularisiert (2.380 → 242 Zeilen, -90%)
+- ✅ Simulator-JavaScript in 7 ES6-Module aufgeteilt
+- ✅ Simulator-CSS in separate Datei ausgelagert
+- ✅ README.md mit Simulator-Dokumentation aktualisiert
+
+### v2.0 (2025-01-XX) - Balance-Modularisierung
+- ✅ Balance.html modularisiert (2.411 → 255 Zeilen, -89%)
+- ✅ CSS in separate Datei ausgelagert (css/balance.css)
+- ✅ JavaScript in separate Datei ausgelagert (js/balance/balance-app.js)
 - ✅ Ordnerstruktur angelegt (css/, js/balance/, js/simulator/, js/shared/)
 - ✅ README.md erstellt
 
 ### v1.0 (Original)
-- Balance-App (v21.1)
-- Simulator-App (v5)
+- Balance-App (v21.1) - Monolithisch
+- Simulator-App (v5) - Monolithisch
 - Engine API v31.0
 
 ## 🤝 Beiträge
 
-Dieses Projekt wurde modularisiert, um die Wartbarkeit und Erweiterbarkeit zu verbessern.
+Beide Apps wurden vollständig modularisiert, um die Wartbarkeit und Erweiterbarkeit zu verbessern.
 
 **Nächste Schritte für Contributors:**
-1. Simulator.html modularisieren
-2. Gemeinsame Komponenten in js/shared/ auslagern
-3. Build-System einrichten
-4. Tests hinzufügen
+1. ~~Simulator.html modularisieren~~ (✅ Erledigt!)
+2. Balance-App auf ES6-Module umstellen (analog zu Simulator)
+3. Gemeinsame Komponenten in js/shared/ auslagern
+4. Build-System einrichten (Vite/esbuild)
+5. Testing-Framework aufsetzen (Jest/Vitest)
+6. TypeScript-Migration planen
 
 ## 📄 Lizenz
 
@@ -226,4 +304,4 @@ Dieses Projekt wurde modularisiert, um die Wartbarkeit und Erweiterbarkeit zu ve
 
 ---
 
-**Hinweis:** Die Original-Datei wurde als `Balance.html.backup` gesichert.
+**Hinweis:** Die Original-Balance-Datei wurde als `Balance.html.backup` gesichert.


### PR DESCRIPTION
- Update project structure to show all 7 Simulator ES6 modules
- Add Simulator before/after comparison table (2,380 → 242 lines, -90%)
- Document module breakdown and responsibilities
- Add Simulator architecture diagram showing module dependencies
- Update usage section to include both apps
- Mark Simulator modularization as completed in roadmap
- Update version history to v3.0
- Improve contributor guidelines with completed tasks

The Simulator app has been fully modularized into ES6 modules:
- simulator-main.js (559) - Orchestration
- simulator-engine.js (411) - Simulation logic
- simulator-portfolio.js (343) - Portfolio management
- simulator-heatmap.js (315) - Visualization
- simulator-results.js (297) - Results rendering
- simulator-utils.js (146) - Utilities
- simulator-data.js (84) - Constants & data