### PR TITLE
Fix undefined error in smoke test when accessing verwendungen

### DIFF
--- a/sim-parity-smoketest.js
+++ b/sim-parity-smoketest.js
@@ -232,21 +232,23 @@ function runEngineYear(engineInput, lastState, yearData, simInputs) {
                 engineInput.goldCost -= engineInput.goldCost * anteil;
             }
         });
-        const liqErhöhung = result.ui.action.verwendungen.liquiditaet || 0;
+        const liqErhöhung = result.ui.action.verwendungen?.liquiditaet || 0;
         const liqGesamt = engineInput.tagesgeld + engineInput.geldmarktEtf;
         const split = liqGesamt > 0 ? engineInput.tagesgeld / liqGesamt : 0.5;
         engineInput.tagesgeld += liqErhöhung * split;
         engineInput.geldmarktEtf += liqErhöhung * (1 - split);
     }
 
-    // Wende Käufe an
-    if (result.ui.action.verwendungen.aktien > 0) {
-        engineInput.depotwertNeu += result.ui.action.verwendungen.aktien;
-        engineInput.costBasisNeu += result.ui.action.verwendungen.aktien;
-    }
-    if (result.ui.action.verwendungen.gold > 0) {
-        engineInput.goldWert += result.ui.action.verwendungen.gold;
-        engineInput.goldCost += result.ui.action.verwendungen.gold;
+    // Wende Käufe an (nur bei TRANSACTION)
+    if (result.ui.action.verwendungen) {
+        if (result.ui.action.verwendungen.aktien > 0) {
+            engineInput.depotwertNeu += result.ui.action.verwendungen.aktien;
+            engineInput.costBasisNeu += result.ui.action.verwendungen.aktien;
+        }
+        if (result.ui.action.verwendungen.gold > 0) {
+            engineInput.goldWert += result.ui.action.verwendungen.gold;
+            engineInput.goldCost += result.ui.action.verwendungen.gold;
+        }
     }
 
     // Entnahme


### PR DESCRIPTION
The smoke test was failing with "Cannot read properties of undefined (reading 'aktien')" because it tried to access result.ui.action.verwendungen without checking if it exists.

The Engine returns two types of actions:
- type: 'TRANSACTION' - has a verwendungen object
- type: 'NONE' - has NO verwendungen object

Fixed by:
- Adding optional chaining (?.) at line 235 for safe access to verwendungen.liquiditaet
- Wrapping verwendungen.aktien and verwendungen.gold checks in an existence check