### PR TITLE
Add debug mode with CTRL+Shift+D keyboard shortcut to Balance App

### DIFF
--- a/Balance.html
+++ b/Balance.html
@@ -16,6 +16,11 @@
     <div class="main-layout">
         <div id="engine-version-alert" role="alert" tabindex="-1" style="display:none; padding: 15px; background-color: var(--warning-color); color: #000; font-weight: bold; text-align: center; margin-bottom: 15px; border-radius: 8px; grid-column: 1 / -1;"></div>
 
+        <!-- Debug-Modus Indikator -->
+        <div id="debugModeIndicator" style="display: none; padding: 8px 15px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; font-weight: bold; text-align: center; margin-bottom: 10px; border-radius: 8px; grid-column: 1 / -1; font-size: 0.85rem; box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);">
+            🐛 DEBUG-MODUS AKTIV | CTRL+Shift+D zum Deaktivieren
+        </div>
+
         <div class="form-column panel">
             <div class="app-header">
                 <h1>Ruhestand-Balancing</h1>

--- a/balance-binder.js
+++ b/balance-binder.js
@@ -6,7 +6,7 @@
  * ===================================================================================
  */
 
-import { CONFIG, AppError, StorageError } from './balance-config.js';
+import { CONFIG, AppError, StorageError, DebugUtils } from './balance-config.js';
 import { UIUtils } from './balance-utils.js';
 import { UIReader } from './balance-reader.js';
 import { UIRenderer } from './balance-renderer.js';
@@ -30,6 +30,9 @@ export function initUIBinder(domRefs, state, updateFn, debouncedUpdateFn) {
 
 export const UIBinder = {
     bindUI() {
+        // Keyboard shortcuts
+        document.addEventListener('keydown', this.handleKeyboardShortcuts.bind(this));
+
         dom.containers.form.addEventListener('input', this.handleFormInput.bind(this));
         dom.containers.form.addEventListener('change', this.handleFormChange.bind(this));
         document.querySelectorAll('input.currency').forEach(el => {
@@ -72,6 +75,68 @@ export const UIBinder = {
         dom.diagnosis.filterToggle.addEventListener('change', (e) => {
             dom.diagnosis.content.classList.toggle('filter-inactive', e.target.checked)
         });
+    },
+
+    handleKeyboardShortcuts(e) {
+        // CTRL+Shift+D: Debug-Modus umschalten
+        if (e.ctrlKey && e.shiftKey && e.key === 'D') {
+            e.preventDefault();
+            const newState = DebugUtils.toggleDebugMode();
+
+            // UI-Indikator aktualisieren
+            this.updateDebugModeUI(newState);
+
+            // Wenn aktiviert: Diagnose-Panel öffnen
+            if (newState) {
+                dom.diagnosis.drawer.classList.add('is-open');
+                dom.diagnosis.overlay.classList.add('is-open');
+            }
+
+            UIRenderer.toast(newState ? '🐛 Debug-Modus aktiviert' : '🐛 Debug-Modus deaktiviert');
+            return;
+        }
+
+        // Alt+J: Jahresabschluss
+        if (e.altKey && e.key === 'j') {
+            e.preventDefault();
+            dom.controls.jahresabschlussBtn.click();
+            return;
+        }
+
+        // Alt+E: Export
+        if (e.altKey && e.key === 'e') {
+            e.preventDefault();
+            dom.controls.exportBtn.click();
+            return;
+        }
+
+        // Alt+I: Import
+        if (e.altKey && e.key === 'i') {
+            e.preventDefault();
+            dom.controls.importBtn.click();
+            return;
+        }
+
+        // Alt+N: Marktdaten nachrücken
+        if (e.altKey && e.key === 'n') {
+            e.preventDefault();
+            dom.controls.btnNachruecken.click();
+            return;
+        }
+
+        // Alt+D: Dark-Mode umschalten
+        if (e.altKey && e.key === 'd') {
+            e.preventDefault();
+            this.handleThemeToggle();
+            return;
+        }
+    },
+
+    updateDebugModeUI(isActive) {
+        const debugIndicator = document.getElementById('debugModeIndicator');
+        if (debugIndicator) {
+            debugIndicator.style.display = isActive ? 'flex' : 'none';
+        }
     },
 
     handleFormInput(e) {

--- a/balance-config.js
+++ b/balance-config.js
@@ -18,7 +18,11 @@ export const CONFIG = {
     STORAGE: {
         LS_KEY: `ruhestandsmodellValues_v29_guardrails`,
         MIGRATION_FLAG: 'migration_v29_inflation_sanitized',
-        SNAPSHOT_PREFIX: 'ruhestandsmodell_snapshot_'
+        SNAPSHOT_PREFIX: 'ruhestandsmodell_snapshot_',
+        DEBUG_MODE_KEY: 'balance_debug_mode'
+    },
+    DEBUG: {
+        ENABLED: false  // wird zur Laufzeit gesetzt
     }
 };
 
@@ -52,3 +56,69 @@ export class StorageError extends AppError {
         this.name = 'StorageError';
     }
 }
+
+// DEBUG UTILITIES
+export const DebugUtils = {
+    /**
+     * Prüft ob Debug-Modus über URL-Parameter oder localStorage aktiviert ist
+     */
+    isDebugMode() {
+        // Prüfe URL-Parameter ?dev=true oder ?dev=1
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlDebug = urlParams.get('dev') === 'true' || urlParams.get('dev') === '1';
+
+        // Prüfe localStorage
+        const storageDebug = localStorage.getItem(CONFIG.STORAGE.DEBUG_MODE_KEY) === 'true';
+
+        return urlDebug || storageDebug;
+    },
+
+    /**
+     * Aktiviert oder deaktiviert den Debug-Modus
+     */
+    toggleDebugMode() {
+        const currentState = this.isDebugMode();
+        const newState = !currentState;
+
+        if (newState) {
+            localStorage.setItem(CONFIG.STORAGE.DEBUG_MODE_KEY, 'true');
+            console.log('%c🐛 DEBUG MODE ACTIVATED', 'background: #222; color: #bada55; font-size: 14px; padding: 4px 8px; border-radius: 4px;');
+        } else {
+            localStorage.removeItem(CONFIG.STORAGE.DEBUG_MODE_KEY);
+            console.log('%c🐛 DEBUG MODE DEACTIVATED', 'background: #222; color: #ff6b6b; font-size: 14px; padding: 4px 8px; border-radius: 4px;');
+        }
+
+        CONFIG.DEBUG.ENABLED = newState;
+        return newState;
+    },
+
+    /**
+     * Initialisiert Debug-Modus beim App-Start
+     */
+    initDebugMode() {
+        const isDebug = this.isDebugMode();
+        CONFIG.DEBUG.ENABLED = isDebug;
+
+        if (isDebug) {
+            console.log('%c🐛 DEBUG MODE ENABLED', 'background: #222; color: #bada55; font-size: 14px; padding: 4px 8px; border-radius: 4px;');
+            console.log('Debug mode can be toggled with CTRL+Shift+D');
+        }
+
+        return isDebug;
+    },
+
+    /**
+     * Logged Debug-Informationen (nur wenn Debug-Modus aktiv)
+     */
+    log(category, message, data = null) {
+        if (!CONFIG.DEBUG.ENABLED) return;
+
+        const timestamp = new Date().toLocaleTimeString('de-DE');
+        console.group(`%c[${timestamp}] ${category}`, 'color: #3b82f6; font-weight: bold;');
+        console.log(message);
+        if (data) {
+            console.log('Data:', data);
+        }
+        console.groupEnd();
+    }
+};


### PR DESCRIPTION
Features implemented:
- Debug mode can be toggled with CTRL+Shift+D keyboard shortcut
- Debug mode can be activated via URL parameter ?dev=true or ?dev=1
- Debug mode state is persisted in localStorage
- Visual debug indicator banner when debug mode is active
- Enhanced console logging for debugging (inputs, engine results, diagnosis)
- Automatic opening of diagnosis panel when debug mode is activated

Additional improvements:
- Implemented all documented keyboard shortcuts (Alt+J, Alt+E, Alt+I, Alt+N, Alt+D)
- Added DebugUtils utility module for centralized debug functionality
- Debug logging only outputs when debug mode is enabled

Files modified:
- balance-config.js: Added DEBUG config, DEBUG_MODE_KEY, DebugUtils
- balance-binder.js: Added keyboard shortcuts handler, debug mode toggle
- balance-main.js: Integrated debug mode initialization and logging
- Balance.html: Added debug mode indicator banner