### PR TITLE
Set realistic sweep parameter defaults with localStorage

### DIFF
--- a/Simulator.html
+++ b/Simulator.html
@@ -266,13 +266,13 @@
                     </div>
                 </div>
                 <div class="form-grid-four-col">
-                    <div class="form-group"><label for="sweepRunwayMin">Runway Min (Monate)</label><input type="text" id="sweepRunwayMin" value="24:24:24" placeholder="18:6:36" title="Beispiel: 18:6:36 (Range) oder 24,30,36 (Liste) oder 24 (Einzelwert)"></div>
-                    <div class="form-group"><label for="sweepRunwayTarget">Runway Target (Monate)</label><input type="text" id="sweepRunwayTarget" value="24:12:48" placeholder="24:6:48" title="Beispiel: 24:6:48 (Range) oder 24,36,48 (Liste) oder 36 (Einzelwert)"></div>
-                    <div class="form-group"><label for="sweepTargetEq">Target Eq (%)</label><input type="text" id="sweepTargetEq" value="50:10:80" placeholder="40,50,60,70" title="Beispiel: 40,50,60,70 (Liste) oder 50:10:80 (Range) oder 60 (Einzelwert)"></div>
-                    <div class="form-group"><label for="sweepRebalBand">Rebal Band (%)</label><input type="text" id="sweepRebalBand" value="5:5:5" placeholder="3,5,7" title="Beispiel: 3,5,7 (Liste) oder 3:2:9 (Range) oder 5 (Einzelwert)"></div>
-                    <div class="form-group"><label for="sweepMaxSkimPct">Max Skim % of Eq</label><input type="text" id="sweepMaxSkimPct" value="5:5:15" placeholder="0,2,4" title="Beispiel: 0,2,4 (Liste) oder 0:2:6 (Range) oder 2 (Einzelwert)"></div>
-                    <div class="form-group"><label for="sweepMaxBearRefillPct">Max Bear Refill % of Eq</label><input type="text" id="sweepMaxBearRefillPct" value="5:5:5" placeholder="0,2,4,6" title="Beispiel: 0,2,4,6 (Liste) oder 0:2:8 (Range) oder 4 (Einzelwert)"></div>
-                    <div class="form-group"><label for="sweepGoldTargetPct">Gold Target (%)</label><input type="text" id="sweepGoldTargetPct" value="5:5:5" placeholder="0,2.5,5,7.5,10" title="Beispiel: 0,2.5,5,7.5,10 (Liste) oder 0:2.5:10 (Range) oder 5 (Einzelwert)"></div>
+                    <div class="form-group"><label for="sweepRunwayMin">Runway Min (Monate)</label><input type="text" id="sweepRunwayMin" value="18" placeholder="12,18,24" title="Format: start:step:end (z.B. 18:6:36) oder Liste 12,18,24 oder Einzelwert 18"></div>
+                    <div class="form-group"><label for="sweepRunwayTarget">Runway Target (Monate)</label><input type="text" id="sweepRunwayTarget" value="24" placeholder="18:6:36" title="Format: start:step:end (z.B. 18:6:36) oder Liste 18,24,30 oder Einzelwert 24"></div>
+                    <div class="form-group"><label for="sweepTargetEq">Target Eq (%)</label><input type="text" id="sweepTargetEq" value="60" placeholder="50,60,70" title="Format: start:step:end (z.B. 50:10:80) oder Liste 50,60,70 oder Einzelwert 60"></div>
+                    <div class="form-group"><label for="sweepRebalBand">Rebal Band (%)</label><input type="text" id="sweepRebalBand" value="5" placeholder="3,5,7" title="Format: start:step:end (z.B. 3:2:9) oder Liste 3,5,7 oder Einzelwert 5"></div>
+                    <div class="form-group"><label for="sweepMaxSkimPct">Max Skim % of Eq</label><input type="text" id="sweepMaxSkimPct" value="2" placeholder="0,2,4" title="Format: start:step:end (z.B. 0:2:6) oder Liste 0,2,4 oder Einzelwert 2"></div>
+                    <div class="form-group"><label for="sweepMaxBearRefillPct">Max Bear Refill % of Eq</label><input type="text" id="sweepMaxBearRefillPct" value="2" placeholder="0,2,4" title="Format: start:step:end (z.B. 0:2:8) oder Liste 0,2,4 oder Einzelwert 2"></div>
+                    <div class="form-group"><label for="sweepGoldTargetPct">Gold Target (%)</label><input type="text" id="sweepGoldTargetPct" value="7.5" placeholder="0,2.5,5,7.5" title="Format: start:step:end (z.B. 0:2.5:10) oder Liste 0,2.5,5,7.5 oder Einzelwert 7.5"></div>
                 </div>
             </fieldset>
             <button id="sweepButton" onclick="runParameterSweep()">Run Sweep</button>

--- a/simulator-main.js
+++ b/simulator-main.js
@@ -643,7 +643,38 @@ window.onload = function() {
 
     // Initial update
     updateSweepGridSize();
+
+    // Sweep defaults with localStorage persistence
+    initSweepDefaultsWithLocalStorageFallback();
 };
+
+/**
+ * Initialisiert Sweep-Defaults mit localStorage-Fallback
+ */
+function initSweepDefaultsWithLocalStorageFallback() {
+    const map = [
+        ["sweepRunwayMin", "sim.sweep.runwayMin"],
+        ["sweepRunwayTarget", "sim.sweep.runwayTarget"],
+        ["sweepTargetEq", "sim.sweep.targetEq"],
+        ["sweepRebalBand", "sim.sweep.rebalBand"],
+        ["sweepMaxSkimPct", "sim.sweep.maxSkimPct"],
+        ["sweepMaxBearRefillPct", "sim.sweep.maxBearRefillPct"],
+        ["sweepGoldTargetPct", "sim.sweep.goldTarget"]
+    ];
+
+    for (const [id, key] of map) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+
+        const saved = localStorage.getItem(key);
+        if (saved !== null && saved !== undefined && saved !== '') {
+            el.value = saved;
+        }
+
+        el.addEventListener("change", () => localStorage.setItem(key, el.value));
+        el.addEventListener("input", () => localStorage.setItem(key, el.value));
+    }
+}
 
 /**
  * Führt einen Parameter-Sweep durch


### PR DESCRIPTION
Sets realistic single-value defaults for Parameter-Sweep fields:
- Runway Min: 18 months
- Runway Target: 24 months
- Target Eq: 60%
- Rebal Band: 5%
- Max Skim/Bear Refill: 2%
- Gold Target: 7.5%

Adds example sweep formats as placeholders (ranges/lists). Implements localStorage persistence for user-modified values.