### PR TITLE
Fix TabStrip annual update depot field

### DIFF
--- a/Balance.html
+++ b/Balance.html
@@ -55,11 +55,6 @@
                             <div class="form-group"><label for="depotwertNeu">Depotwert Neu (€)</label><input id="depotwertNeu" class="currency" type="text" inputmode="numeric" placeholder="z. B. 750.000"></div>
                             <div class="form-group" id="goldWertGroup"><label for="goldWert">Gold-Bestand (€)</label><input id="goldWert" class="currency" type="text" inputmode="numeric" value="0"></div>
                         </div>
-                        <div class="form-group full-width mt-10" id="depotMetaRow" aria-live="polite">
-							<small style="color: var(--info-text-color); display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-							Stand: <span id="depotLastUpdated">—</span>
-							</small>
-						</div>
                     </fieldset>
                     <fieldset><legend style="display: flex; justify-content: space-between; align-items: center; width: 100%;">Marktdaten
                         <span style="display: flex; gap: 6px;">

--- a/balance-binder.js
+++ b/balance-binder.js
@@ -145,7 +145,6 @@ export const UIBinder = {
             const state = StorageManager.loadState();
             state.inputs = { ...(state.inputs || {}), depotLastUpdate: Date.now() };
             StorageManager.saveState(state);
-            UIRenderer.updateDepotMetaUI();
         }
         debouncedUpdate();
     },

--- a/balance-main.js
+++ b/balance-main.js
@@ -43,7 +43,6 @@ const dom = {
     },
     inputs: {}, // Wird in init() gefüllt
     controls: {
-        depotLastUpdated: document.getElementById('depotLastUpdated'),
         themeToggle: document.getElementById('themeToggle'),
         exportBtn: document.getElementById('exportBtn'),
         importBtn: document.getElementById('importBtn'),

--- a/balance-renderer.js
+++ b/balance-renderer.js
@@ -35,7 +35,6 @@ export const UIRenderer = {
         // Übergibt ui.action und das notwendige ui.input an renderHandlungsanweisung
         this.renderHandlungsanweisung(ui.action, ui.input);
         this.renderLiquidityBar(ui.liquiditaet.deckungNachher);
-        this.updateDepotMetaUI();
     },
 
     renderBedarfAnpassungUI(inputData, persistentState) {
@@ -313,13 +312,6 @@ export const UIRenderer = {
         bar.style.width = pct + '%';
         bar.classList.add(pct >= 100 ? 'bar-ok' : pct >= 70 ? 'bar-warn' : 'bar-bad');
         dom.outputs.balkenContainer.setAttribute('aria-valuenow', pct.toFixed(0));
-    },
-
-    updateDepotMetaUI() {
-        const state = StorageManager.loadState();
-        const inputs = state.inputs || {};
-        const tsUpd = inputs.depotLastUpdate ? new Date(inputs.depotLastUpdate) : null;
-        dom.controls.depotLastUpdated.textContent = tsUpd ? tsUpd.toLocaleString('de-DE', {dateStyle: 'short', timeStyle: 'short'}) : '—';
     },
 
     toast(msg, isSuccess = true) {


### PR DESCRIPTION
Removed the deprecated 'Stand: —' field that was displaying below the Depotwert-Alt field in the Jahres-Update tab. This field was a leftover from earlier versions and is no longer needed.

Changes:
- Removed depotMetaRow div from Balance.html
- Removed depotLastUpdated DOM reference from balance-main.js
- Removed updateDepotMetaUI() function from balance-renderer.js
- Removed all calls to updateDepotMetaUI()