### PR TITLE
Fix KPI depot exhaustion metrics calculation

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -475,10 +475,15 @@ const SpendingPlanner = {
         }
 
         // 7. Finale Werte berechnen
-        const finaleKuerzung = inflatedBedarf.flex > 0
-            ? 100 - (Math.max(0, endgueltigeEntnahme - inflatedBedarf.floor) / inflatedBedarf.flex * 100)
-            : 0;
-        const flexRate = 100 - finaleKuerzung;
+        let flexRate;
+        if (inflatedBedarf.flex > 0) {
+            const flexErfuellt = Math.max(0, endgueltigeEntnahme - inflatedBedarf.floor);
+            flexRate = (flexErfuellt / inflatedBedarf.flex) * 100;
+        } else {
+            // Wenn es keinen Flex-Bedarf gibt, ist die Flex-Rate 0%
+            flexRate = 0;
+        }
+        const finaleKuerzung = 100 - flexRate;
 
         // 8. Ergebnisse zusammenstellen
         const { newState, spendingResult } = this._buildResults(
@@ -849,9 +854,8 @@ const SpendingPlanner = {
         const { market, renteJahr, inflatedBedarf } = p;
         const { peakRealVermoegen, currentRealVermoegen, cumulativeInflationFactor } = state.keyParams;
 
-        const finaleKuerzung = inflatedBedarf.flex > 0
-            ? 100 - (Math.max(0, endgueltigeEntnahme - inflatedBedarf.floor) / inflatedBedarf.flex * 100)
-            : 0;
+        // finaleKuerzung ist das Komplement zur flexRate
+        const finaleKuerzung = 100 - flexRate;
         const aktuellesGesamtbudgetFinal = endgueltigeEntnahme + renteJahr;
 
         const newState = {

--- a/engine/planners/SpendingPlanner.js
+++ b/engine/planners/SpendingPlanner.js
@@ -77,10 +77,15 @@ const SpendingPlanner = {
         }
 
         // 7. Finale Werte berechnen
-        const finaleKuerzung = inflatedBedarf.flex > 0
-            ? 100 - (Math.max(0, endgueltigeEntnahme - inflatedBedarf.floor) / inflatedBedarf.flex * 100)
-            : 0;
-        const flexRate = 100 - finaleKuerzung;
+        let flexRate;
+        if (inflatedBedarf.flex > 0) {
+            const flexErfuellt = Math.max(0, endgueltigeEntnahme - inflatedBedarf.floor);
+            flexRate = (flexErfuellt / inflatedBedarf.flex) * 100;
+        } else {
+            // Wenn es keinen Flex-Bedarf gibt, ist die Flex-Rate 0%
+            flexRate = 0;
+        }
+        const finaleKuerzung = 100 - flexRate;
 
         // 8. Ergebnisse zusammenstellen
         const { newState, spendingResult } = this._buildResults(
@@ -451,9 +456,8 @@ const SpendingPlanner = {
         const { market, renteJahr, inflatedBedarf } = p;
         const { peakRealVermoegen, currentRealVermoegen, cumulativeInflationFactor } = state.keyParams;
 
-        const finaleKuerzung = inflatedBedarf.flex > 0
-            ? 100 - (Math.max(0, endgueltigeEntnahme - inflatedBedarf.floor) / inflatedBedarf.flex * 100)
-            : 0;
+        // finaleKuerzung ist das Komplement zur flexRate
+        const finaleKuerzung = 100 - flexRate;
         const aktuellesGesamtbudgetFinal = endgueltigeEntnahme + renteJahr;
 
         const newState = {


### PR DESCRIPTION
Problem: Die KPI 'Median-Anteil Jahre ohne Flex' wurde nicht korrekt befüllt, weil die flexRate-Berechnung fehlerhaft war.

Root Cause: Wenn kein Flex-Bedarf vorhanden war (inflatedBedarf.flex <= 0), wurde die flexRate fälschlicherweise auf 100% gesetzt anstatt auf 0%. Dies führte dazu, dass Jahre ohne Flex-Bedarf nicht als "Jahre ohne Flex" gezählt wurden.

Lösung:
- SpendingPlanner.js: flexRate wird jetzt korrekt auf 0% gesetzt, wenn kein Flex-Bedarf vorhanden ist
- engine.js: Gleiche Korrektur angewendet
- _buildResults(): finaleKuerzung wird nun direkt als (100 - flexRate) berechnet, um Redundanz zu vermeiden

Die KPI sollte nun korrekt die Jahre erfassen, in denen der Flex-Anteil vollständig gekürzt wurde oder gar nicht vorhanden war.