### PR TITLE
Test new functionality

### DIFF
--- a/simulator-engine.js
+++ b/simulator-engine.js
@@ -3,7 +3,7 @@
 import { shortenReasonText } from './simulator-utils.js';
 import { HISTORICAL_DATA, PFLEGE_STUFE1_WAHRSCHEINLICHKEIT, annualData, REGIME_DATA, REGIME_TRANSITIONS } from './simulator-data.js';
 import {
-    computeYearlyPension, initializePortfolio, applySaleToPortfolio, summarizeSalesByAsset,
+    computeYearlyPension, computeTwoPersonPensions, initializePortfolio, applySaleToPortfolio, summarizeSalesByAsset,
     buildInputsCtxFromPortfolio, sumDepot, buyGold, buyStocksNeu
 } from './simulator-portfolio.js';
 import { resolveProfileKey } from './simulator-heatmap.js';
@@ -19,7 +19,7 @@ import { resolveProfileKey } from './simulator-heatmap.js';
  * @returns {Object} Simulationsergebnisse
  */
 export function simulateOneYear(currentState, inputs, yearData, yearIndex, pflegeMeta = null, personStatus = null) {
-    let { portfolio, baseFloor, baseFlex, lastState, currentAnnualPension, marketDataHist } = currentState;
+    let { portfolio, baseFloor, baseFlex, lastState, currentAnnualPension, currentPensions, marketDataHist } = currentState;
     let { depotTranchesAktien, depotTranchesGold } = portfolio;
     let liquiditaet = portfolio.liquiditaet;
     let totalTaxesThisYear = 0;
@@ -41,7 +41,34 @@ export function simulateOneYear(currentState, inputs, yearData, yearIndex, pfleg
     const algoInput = { ...inputs, floorBedarf: baseFloor, flexBedarf: baseFlex, startSPB: inputs.startSPB };
     const market = window.Ruhestandsmodell_v30.analyzeMarket(marketDataCurrentYear);
 
-    const pensionAnnual = computeYearlyPension({ yearIndex, baseMonthly: inputs.renteMonatlich, startOffset: inputs.renteStartOffsetJahre, lastAnnualPension: currentAnnualPension, indexierungsArt: inputs.renteIndexierungsart, inflRate: yearData.inflation, lohnRate: yearData.lohn, festerSatz: inputs.renteFesterSatz });
+    // Berechne Renten für Ein- oder Zwei-Personen-Haushalt
+    let pensionAnnual, pension1, pension2;
+    if (inputs.zweiPersonenHaushalt && currentPensions) {
+        const pensionResult = computeTwoPersonPensions({
+            yearIndex,
+            inputs,
+            lastPensions: currentPensions,
+            personStatus: personStatus || { person1Alive: true, person2Alive: true },
+            inflRate: yearData.inflation,
+            lohnRate: yearData.lohn
+        });
+        pensionAnnual = pensionResult.total;
+        pension1 = pensionResult.person1;
+        pension2 = pensionResult.person2;
+    } else {
+        pensionAnnual = computeYearlyPension({
+            yearIndex,
+            baseMonthly: inputs.renteMonatlich,
+            startOffset: inputs.renteStartOffsetJahre,
+            lastAnnualPension: currentAnnualPension,
+            indexierungsArt: inputs.renteIndexierungsart,
+            inflRate: yearData.inflation,
+            lohnRate: yearData.lohn,
+            festerSatz: inputs.renteFesterSatz
+        });
+        pension1 = pensionAnnual;
+        pension2 = 0;
+    }
     const inflatedFloor = Math.max(0, baseFloor - pensionAnnual);
     const inflatedFlex  = baseFlex;
 
@@ -154,17 +181,24 @@ export function simulateOneYear(currentState, inputs, yearData, yearIndex, pfleg
     const naechsterBaseFloor = baseFloor * inflFactorThisYear;
     const naechsterBaseFlex = baseFlex * inflFactorThisYear;
 
+    // Bei Zwei-Personen-Haushalt: Separate Pension-States aktualisieren
+    const newStateBase = {
+        portfolio: { ...portfolio, liquiditaet },
+        baseFloor: naechsterBaseFloor,
+        baseFlex: naechsterBaseFlex,
+        lastState: spendingNewState,
+        currentAnnualPension: pensionAnnual,
+        marketDataHist: newMarketDataHist,
+        samplerState: currentState.samplerState
+    };
+
+    if (inputs.zweiPersonenHaushalt && currentPensions) {
+        newStateBase.currentPensions = { person1: pension1, person2: pension2 };
+    }
+
     return {
         isRuin: false,
-        newState: {
-            portfolio: { ...portfolio, liquiditaet },
-            baseFloor: naechsterBaseFloor,
-            baseFlex: naechsterBaseFlex,
-            lastState: spendingNewState,
-            currentAnnualPension: pensionAnnual,
-            marketDataHist: newMarketDataHist,
-            samplerState: currentState.samplerState
-        },
+        newState: newStateBase,
         logData: {
             entscheidung: { ...spendingResult, jahresEntnahme, runwayMonths, kuerzungProzent: spendingResult.kuerzungProzent },
             FlexRatePct: spendingResult.details.flexRate,
@@ -186,6 +220,8 @@ export function simulateOneYear(currentState, inputs, yearData, yearIndex, pfleg
             usedSPB: mergedSaleResult ? (mergedSaleResult.pauschbetragVerbraucht || 0) : 0,
             floor_brutto: baseFloor,
             pension_annual: pensionAnnual,
+            pension_person1: pension1,
+            pension_person2: pension2,
             floor_aus_depot: inflatedFloor,
             flex_brutto: baseFlex,
             flex_erfuellt_nominal: jahresEntnahme > inflatedFloor ? jahresEntnahme - inflatedFloor : 0,

--- a/simulator-results.js
+++ b/simulator-results.js
@@ -220,6 +220,8 @@ export function renderWorstRunLog(logRows, caR_Threshold, opts = {}) {
         { key: 'entscheidung.jahresEntnahme', header: 'Entn.', width: 7, fmt: formatCurrencyShortLog },
         { key: 'floor_brutto', header: 'Floor', width: 7, fmt: formatCurrencyShortLog },
         { key: 'pension_annual', header: 'Rente', width: 7, fmt: formatCurrencyShortLog },
+        { key: 'pension_person1', header: 'Rent1', width: 7, fmt: formatCurrencyShortLog },
+        { key: 'pension_person2', header: 'Rent2', width: 7, fmt: formatCurrencyShortLog },
     ];
 
     const careColsMinimal = [


### PR DESCRIPTION
…eben

Problem:
- Im Backtest-Log wurde nur die Rente der ersten Person ausgegeben
- Die Rente der zweiten Person wurde nicht angezeigt, obwohl sie berechnet wurde

Lösung:
- computeTwoPersonPensions wird nun für Zwei-Personen-Haushalte verwendet
- State enthält jetzt currentPensions für beide Personen
- Log zeigt nun drei Spalten: Rente (Gesamt), Rent1 (Person 1), Rent2 (Person 2)

Geänderte Dateien:
- simulator-engine.js: Rentenberechnung und State-Management für Zwei-Personen
- simulator-results.js: Log-Ausgabe mit separaten Renten-Spalten