### PR TITLE
Enable two-person household in backtest simulation

### DIFF
--- a/Simulator.html
+++ b/Simulator.html
@@ -146,6 +146,18 @@
                        <div class="form-group"><label for="partnerRenteMonatlich">Partner: Monatliche Rente (€)</label><input type="number" id="partnerRenteMonatlich" value="800"></div>
                        <div class="form-group"><label for="partnerRenteStartOffsetJahre">Partner: Start in ... Jahren</label><input type="number" id="partnerRenteStartOffsetJahre" value="7"></div>
                        <div class="form-group" style="grid-column: span 2;">
+                           <label for="partnerRenteIndexierungsart">Partner: Rentenanpassung koppeln an</label>
+                           <select id="partnerRenteIndexierungsart">
+                               <option value="lohn" selected>Lohnentwicklung (hist. Daten)</option>
+                               <option value="inflation">Inflation (VPI)</option>
+                               <option value="fest">Festen Satz p.a.</option>
+                           </select>
+                       </div>
+                       <div class="form-group" id="partnerFesterSatzContainer" style="display: none;">
+                           <label for="partnerRenteFesterSatz">Partner: Fester Satz (% p.a.)</label>
+                           <input type="number" id="partnerRenteFesterSatz" value="2.0" step="0.1">
+                       </div>
+                       <div class="form-group" style="grid-column: span 2;">
                            <label for="witwenRenteProzent">Witwenrente (% der ursprünglichen Rente)</label>
                            <input type="number" id="witwenRenteProzent" value="55" step="1" min="0" max="100">
                        </div>

--- a/simulator-main.js
+++ b/simulator-main.js
@@ -419,7 +419,7 @@ export function runBacktest() {
             baseFloor: inputs.startFloorBedarf,
             baseFlex: inputs.startFlexBedarf,
             lastState: null,
-            currentAnnualPension: 0,
+            currentAnnualPension: { a: 0, b: 0 },
             marketDataHist: { endeVJ: HISTORICAL_DATA[startJahr-1].msci_eur, endeVJ_1: HISTORICAL_DATA[startJahr-2].msci_eur, endeVJ_2: HISTORICAL_DATA[startJahr-3].msci_eur, endeVJ_3: HISTORICAL_DATA[startJahr-4].msci_eur, ath: 0, jahreSeitAth: 0 }
         };
         simState.marketDataHist.ath = Math.max(...Object.keys(HISTORICAL_DATA).filter(y => y < startJahr).map(y => HISTORICAL_DATA[y].msci_eur));
@@ -575,9 +575,10 @@ window.onload = function() {
         'goldAllokationAktiv', 'goldAllokationProzent', 'goldFloorProzent', 'rebalancingBand',
         'goldSteuerfrei', 'startFloorBedarf', 'startFlexBedarf',
         'einstandAlt', 'startAlter', 'geschlecht', 'startSPB', 'kirchensteuerSatz', 'round5',
-        'renteMonatlich', 'renteStartOffsetJahre', 'renteIndexierungsart',
+        'renteMonatlich', 'renteStartOffsetJahre', 'renteIndexierungsart', 'renteFesterSatz',
         'zweiPersonenHaushalt', 'partnerStartAlter', 'partnerGeschlecht', 'partnerStartSPB',
-        'partnerKirchensteuerSatz', 'partnerRenteMonatlich', 'partnerRenteStartOffsetJahre', 'witwenRenteProzent',
+        'partnerKirchensteuerSatz', 'partnerRenteMonatlich', 'partnerRenteStartOffsetJahre',
+        'partnerRenteIndexierungsart', 'partnerRenteFesterSatz', 'witwenRenteProzent',
         'pflegefallLogikAktivieren', 'pflegeModellTyp', 'pflegeStufe1Zusatz', 'pflegeStufe1FlexCut',
         'pflegeMaxFloor', 'pflegeRampUp', 'pflegeMinDauer', 'pflegeMaxDauer', 'pflegeKostenDrift',
         'pflegebeschleunigtMortalitaetAktivieren', 'pflegeTodesrisikoFaktor',
@@ -607,6 +608,11 @@ window.onload = function() {
 
     const renteIndexArtSelect = document.getElementById('renteIndexierungsart');
     renteIndexArtSelect.addEventListener('change', () => { document.getElementById('festerSatzContainer').style.display = renteIndexArtSelect.value === 'fest' ? 'block' : 'none'; });
+
+    const partnerRenteIndexArtSelect = document.getElementById('partnerRenteIndexierungsart');
+    if (partnerRenteIndexArtSelect) {
+        partnerRenteIndexArtSelect.addEventListener('change', () => { document.getElementById('partnerFesterSatzContainer').style.display = partnerRenteIndexArtSelect.value === 'fest' ? 'block' : 'none'; });
+    }
 
     const pflegeCheckbox = document.getElementById('pflegefallLogikAktivieren');
     pflegeCheckbox.addEventListener('change', () => { document.getElementById('pflegePanel').style.display = pflegeCheckbox.checked ? 'grid' : 'none'; });
@@ -650,6 +656,9 @@ window.onload = function() {
 
     document.getElementById('mcBlockSize').disabled = mcMethodeSelect.value !== 'block';
     document.getElementById('festerSatzContainer').style.display = renteIndexArtSelect.value === 'fest' ? 'block' : 'none';
+    if (partnerRenteIndexArtSelect) {
+        document.getElementById('partnerFesterSatzContainer').style.display = partnerRenteIndexArtSelect.value === 'fest' ? 'block' : 'none';
+    }
     document.getElementById('partnerPanel').style.display = zweiPersonenCheckbox.checked ? 'grid' : 'none';
     document.getElementById('pflegePanel').style.display = pflegeCheckbox.checked ? 'grid' : 'none';
     document.getElementById('pflegeDauerContainer').style.display = pflegeModellSelect.value === 'akut' ? 'contents' : 'none';

--- a/simulator-portfolio.js
+++ b/simulator-portfolio.js
@@ -63,7 +63,20 @@ export function getCommonInputs() {
         maxBearRefillPctOfEq: 5
     };
 
-    return { ...baseInputs, ...strategyConstants };
+    // Partner-Objekt für Backtest (wenn Indexierungs-Felder vorhanden)
+    const partnerIndexArtEl = document.getElementById('partnerRenteIndexierungsart');
+    let partner = null;
+    if (zweiPersonen && partnerIndexArtEl) {
+        partner = {
+            renteMonatlich: parseFloat(document.getElementById('partnerRenteMonatlich').value) || 0,
+            renteStartOffsetJahre: parseInt(document.getElementById('partnerRenteStartOffsetJahre').value) || 0,
+            renteIndexierungsart: partnerIndexArtEl.value || 'lohn',
+            renteFesterSatz: parseFloat(document.getElementById('partnerRenteFesterSatz').value) || 0,
+            startSPB: parseFloat(document.getElementById('partnerStartSPB').value) || 0
+        };
+    }
+
+    return { ...baseInputs, ...strategyConstants, partner };
 }
 
 /**


### PR DESCRIPTION
…nd SPB

Implements simplified two-person household support for backtesting without mortality logic. Both partners are always "alive" in backtest scenarios.

Changes:
- UI: Added partner pension indexation fields (indexierungsart, fester Satz)
- simulator-portfolio.js: Extended getCommonInputs() to create partner object
- simulator-engine.js: Added computeHouseholdPensionAndSPB() for household aggregation
- simulator-engine.js: Adapted simulateOneYear() to use household logic for backtest
- simulator-main.js: Updated runBacktest() to initialize pension state as {a, b}
- simulator-main.js: Added event listeners for partner indexation UI

Features:
- Partner pension with independent start offset and indexation (lohn/inflation/fest)
- Combined SPB (Sparer-Pauschbetrag) for both partners in backtest
- Backward compatible: single-person backtests remain unchanged
- Monte-Carlo two-person logic with mortality remains unchanged

Backtest log now shows combined pension of both persons in "Rente" column. Net floor decreases when partner pension starts.