### PR TITLE
Extend Monte Carlo pipeline for two-person pensions

### DIFF
--- a/simulator-portfolio.js
+++ b/simulator-portfolio.js
@@ -38,6 +38,8 @@ export function getCommonInputs() {
         partnerKirchensteuerSatz: zweiPersonen ? (parseFloat(document.getElementById('partnerKirchensteuerSatz').value) || 0) : 0,
         partnerRenteMonatlich: zweiPersonen ? (parseFloat(document.getElementById('partnerRenteMonatlich').value) || 0) : 0,
         partnerRenteStartOffsetJahre: zweiPersonen ? (parseInt(document.getElementById('partnerRenteStartOffsetJahre').value) || 0) : 0,
+        partnerRenteIndexierungsart: zweiPersonen ? (document.getElementById('partnerRenteIndexierungsart')?.value || 'lohn') : 'lohn',
+        partnerRenteFesterSatz: zweiPersonen ? (parseFloat(document.getElementById('partnerRenteFesterSatz')?.value) || 0) : 0,
         witwenRenteProzent: zweiPersonen ? (parseFloat(document.getElementById('witwenRenteProzent').value) || 55) : 55,
         pflegefallLogikAktivieren: document.getElementById('pflegefallLogikAktivieren').checked,
         pflegeModellTyp: document.getElementById('pflegeModellTyp').value,

--- a/simulator-results.js
+++ b/simulator-results.js
@@ -220,8 +220,8 @@ export function renderWorstRunLog(logRows, caR_Threshold, opts = {}) {
         { key: 'entscheidung.jahresEntnahme', header: 'Entn.', width: 7, fmt: formatCurrencyShortLog },
         { key: 'floor_brutto', header: 'Floor', width: 7, fmt: formatCurrencyShortLog },
         { key: 'pension_annual', header: 'Rente', width: 7, fmt: formatCurrencyShortLog },
-        { key: 'pension_person1', header: 'Rent1', width: 7, fmt: formatCurrencyShortLog },
-        { key: 'pension_person2', header: 'Rent2', width: 7, fmt: formatCurrencyShortLog },
+        { key: 'pension_person1', header: 'Rent1', width: 6, fmt: formatCurrencyShortLog },
+        { key: 'pension_person2', header: 'Rent2', width: 6, fmt: formatCurrencyShortLog },
     ];
 
     const careColsMinimal = [


### PR DESCRIPTION
- Add partner pension indexing fields (partnerRenteIndexierungsart, partnerRenteFesterSatz) to inputs
- Extend MC state with separate pension tracking (currentAnnualPension1/2, age1/2)
- Split pension calculation into two independent computeYearlyPension() calls
- Update state tracking to maintain separate pension values per person
- Adjust Rent1/Rent2 log column widths for cleaner output

This enables proper two-person pension simulation without engine changes, maintaining backtest parity while providing clean separate tracking.