### PR TITLE
Fix MonteCar function call error

### DIFF
--- a/simulator-engine.js
+++ b/simulator-engine.js
@@ -70,7 +70,7 @@ function computeHouseholdPensionAndSPB({ yearIndex, yearData, lastAnnualPension,
  * @returns {Object} Simulationsergebnisse
  */
 export function simulateOneYear(currentState, inputs, yearData, yearIndex, pflegeMeta = null, personStatus = null) {
-    let { portfolio, baseFloor, baseFlex, lastState, currentAnnualPension, currentPensions, marketDataHist } = currentState;
+    let { portfolio, baseFloor, baseFlex, lastState, currentAnnualPension, currentPensions, currentAnnualPension1, currentAnnualPension2, marketDataHist } = currentState;
     let { depotTranchesAktien, depotTranchesGold } = portfolio;
     let liquiditaet = portfolio.liquiditaet;
     let totalTaxesThisYear = 0;


### PR DESCRIPTION
…OneYear

Fixes ReferenceError where currentAnnualPension1 and currentAnnualPension2 were used but not extracted from currentState in the function parameter destructuring.