### PR TITLE
Fix MonteCarlo error with 2-person household

### DIFF
--- a/simulator-main.js
+++ b/simulator-main.js
@@ -190,6 +190,9 @@ export async function runMonteCarlo() {
                     });
                     lastPensions = { person1: pensions.person1, person2: pensions.person2 };
                     simState.currentAnnualPension = pensions.total;
+                    simState.currentPensions = { person1: pensions.person1, person2: pensions.person2 };
+                    simState.currentAnnualPension1 = pensions.person1;
+                    simState.currentAnnualPension2 = pensions.person2;
                 } else {
                     // Single-Person-Logik (unverändert)
                     careMeta = updateCareMeta(careMeta, inputs, currentAge, yearData, rand);
@@ -983,6 +986,9 @@ export async function runParameterSweep() {
                         });
                         lastPensions = { person1: pensions.person1, person2: pensions.person2 };
                         simState.currentAnnualPension = pensions.total;
+                        simState.currentPensions = { person1: pensions.person1, person2: pensions.person2 };
+                        simState.currentAnnualPension1 = pensions.person1;
+                        simState.currentAnnualPension2 = pensions.person2;
                     } else {
                         careMeta = updateCareMeta(careMeta, inputs, currentAge, yearData, rand);
 


### PR DESCRIPTION
…arlo

Update simState.currentPensions, currentAnnualPension1, and currentAnnualPension2 in simulator-main.js after computing pensions. This ensures simulateOneYear has access to the current pension values and prevents ReferenceError when accessing currentAnnualPension1/2 for two-person households.

Fixes ReferenceError at simulator-engine.js:99 when running MonteCarlo with 2-person households.